### PR TITLE
Fix service validation

### DIFF
--- a/tests/fixtures/error_collection.json
+++ b/tests/fixtures/error_collection.json
@@ -364,6 +364,20 @@
       "error": "Error: 'startCanvas' must refer to the @id of some canvas in this sequence. @ data['sequences'][0]['startCanvas']",
       "@id": "http://iiif.io/api/presentation/2.0/example/errors/51/manifest.json",
       "@type": "sc:Manifest"
+    },
+    {
+      "label": "52: Invalid service with URI instead of JSON-LD object",
+      "manifest": "{\n  \"@context\": \"http://iiif.io/api/presentation/2/context.json\", \n  \"@id\": \"http://iiif.io/api/presentation/2.0/example/errors/manifest.json\", \n  \"@type\": \"sc:Manifest\", \n  \"label\": \"manifest\", \n  \"sequences\": [\n    {\n      \"@type\": \"sc:Sequence\", \n      \"canvases\": [\n        {\n          \"@id\": \"http://iiif.io/api/presentation/2.0/example/errors/canvas/c1.json\", \n          \"@type\": \"sc:Canvas\", \n          \"height\": 1, \n          \"label\": \"canvas\", \n          \"width\": 1,\n      \"service\": \"http://example.net/not/jsonld\"\n        }\n      ]\n    }\n  ]\n}",
+      "error": "Error: Illegal type (MUST be an object): 'http://example.net/not/jsonld' @ data['sequences'][0]['canvases'][0]['service']",
+      "@id": "http://iiif.io/api/presentation/2.0/example/errors/52/manifest.json",
+      "@type": "sc:Manifest"
+    },
+    {
+      "label": "53: Invalid service with missing '@context' key",
+      "manifest": "{\n  \"@context\": \"http://iiif.io/api/presentation/2/context.json\", \n  \"@id\": \"http://iiif.io/api/presentation/2.0/example/errors/manifest.json\", \n  \"@type\": \"sc:Manifest\", \n  \"label\": \"manifest\", \n  \"sequences\": [\n    {\n      \"@type\": \"sc:Sequence\", \n      \"canvases\": [\n        {\n          \"@id\": \"http://iiif.io/api/presentation/2.0/example/errors/canvas/c1.json\", \n          \"@type\": \"sc:Canvas\", \n          \"height\": 1, \n          \"label\": \"canvas\", \n          \"width\": 1,\n      \"service\": {\"@id\": \"http://example.net/some/service\"}\n        }\n      ]\n    }\n  ]\n}",
+      "error": "Error: service MUST be valid JSON-LD, but has no '@context' key where one is required. @ data['sequences'][0]['canvases'][0]['service']",
+      "@id": "http://iiif.io/api/presentation/2.0/example/errors/53/manifest.json",
+      "@type": "sc:Manifest"
     }
   ],
   "@context": "http://iiif.io/api/presentation/2/context.json",

--- a/tripoli/resource_validators/base_validator.py
+++ b/tripoli/resource_validators/base_validator.py
@@ -438,7 +438,7 @@ class BaseValidator(LinkedValidatorMixin, SubValidationMixin):
                                   .format(value))
             return value
         if not '@context' in value:
-            self.log_error(field, "{} must be valid JSON-LD, but has no "
+            self.log_error(field, "{} MUST be valid JSON-LD, but has no "
                                   "'@context' key where one is required."
                                   .format(field))
             return value

--- a/tripoli/resource_validators/base_validator.py
+++ b/tripoli/resource_validators/base_validator.py
@@ -424,6 +424,32 @@ class BaseValidator(LinkedValidatorMixin, SubValidationMixin):
         self.log_error(field, "Got '{}' when expecting string or repeated string.".format(value))
         return value
 
+    def _repeatable_service_type(self, field, value):
+        """ Allow for repeated service types, either referenced or embedded.
+        """
+        if isinstance(value, list):
+            return [self._service_type(field, val) for val in value]
+        else:
+            return self._service_type(field, value)
+
+    def _service_type(self, field, value):
+        if not isinstance(value, dict):
+            self.log_error(field, "Illegal type (MUST be an object): '{}'"
+                                  .format(value))
+            return value
+        if not '@context' in value:
+            self.log_error(field, "{} must be valid JSON-LD, but has no "
+                                  "'@context' key where one is required."
+                                  .format(field))
+            return value
+        if not '@id' in value:
+            self.log_warning(field, "{} SHOULD have an '@id' key.".format(field))
+        if not 'profile' in value:
+            self.log_warning(field, "{} SHOULD have a 'profile' key to "
+                                    "allow for determining the type of service."
+                                    .format(field))
+        return value
+
     def _repeatable_uri_type(self, field, value):
         """Allow single or repeating URIs.
 
@@ -615,7 +641,7 @@ class BaseValidator(LinkedValidatorMixin, SubValidationMixin):
 
     def service_field(self, value):
         """Validate the ``service`` field of the resource."""
-        return self._repeatable_uri_type("service", value)
+        return self._repeatable_service_type("service", value)
 
     def seeAlso_field(self, value):
         """Validate the ``seeAlso`` field of the resource."""


### PR DESCRIPTION
Previously, services were assumed to be one or more URIs. However, the specification states that they must be valid JSON-LD with a '@context' field:

> Service information included in the API responses must be both valid JSON-LD, and include a service-specific @context. Services should have an @id that can be dereferenced, and if so, the representation retrieved from that URI should be JSON-LD. The service at the URI in @id may require additional parameters, generate representations other than JSON-LD, or have no JSON-LD representation at all.
>
> Services should have a profile URI which can be used to determine the type of service, especially for services that do not provide a JSON-LD representation. The representation retrieved from the profile URI should be a human or machine readable description of the service.

(from http://iiif.io/api/annex/services/#requirements)

This PR fixes this by validating that the requirements from the specification are met.